### PR TITLE
Support vim yank sync to local client clipboard with OSC 52

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -13,6 +13,7 @@ set -g @plugin 'tmux-plugins/tmux-copycat'
 set -g @plugin 'tmux-plugins/tmux-sidebar'
 set -g @plugin 'tmux-plugins/tmux-sessionist'
 
+set -g set-clipboard on
 set -g @yank_selection 'clipboard'
 set -g @yank_selection_mouse 'clipboard'
 

--- a/vimrc
+++ b/vimrc
@@ -104,10 +104,19 @@ set wrapscan
 "================================
 set wildmode=list:longest
 set wildchar=<Tab>
-"================================
+"====clipboard settings==========
 set clipboard&
 set clipboard^=unnamedplus
-" TODO: paste mode control
+function! OSCYankReg(reg)
+    let reg_contents = getreg(a:reg)
+    let escaped_reg_contents = escape(reg_contents, '\\')
+    let base64_contents = system("echo  . escaped_reg_contents .  | base64 | tr -d \"\\n\"")
+    let osc52 = "\<Esc>]52;c;" . base64_contents . "\<Esc>\\"
+"   $TTY env var is unset by vim, so _TTY should be set in your .bashrc/.zshrc
+    let current_tty = $_TTY
+    call writefile([osc52], current_tty, "b")
+endfunction
+autocmd TextYankPost * call OSCYankReg(v:event.regname)
 "================================
 call Source_rc("map.vim")
 call Source_rc("command.vim")

--- a/vimrc
+++ b/vimrc
@@ -2,7 +2,6 @@
 filetype off
 filetype plugin indent off
 runtime! ftplugin/man.vim
-
 let g:cache_home = empty($XDG_CACHE_HOME) ? expand('~/.cache') : $XDG_CACHE_HOME
 let g:vim_dir = g:cache_home . '/vim'
 
@@ -113,6 +112,7 @@ function! OSCYankReg(reg)
     let reg_contents = escape(reg_contents, '\\')
     let reg_contents = escape(reg_contents, '"')
     let reg_contents = escape(reg_contents, '$')
+"   TODO: encode contents without shell call to avoid shell escape issue
     let base64_contents = system('echo -n "'. reg_contents .'" | base64 |' .  "tr -d '\\n'")
     let osc52 = "\<Esc>]52;c;" . base64_contents . "\<Esc>\\"
 "   $TTY env var is unset by vim, so _TTY should be set in your .bashrc/.zshrc

--- a/vimrc
+++ b/vimrc
@@ -109,8 +109,11 @@ set clipboard&
 set clipboard^=unnamedplus
 function! OSCYankReg(reg)
     let reg_contents = getreg(a:reg)
-    let escaped_reg_contents = escape(reg_contents, '\\')
-    let base64_contents = system("echo  . escaped_reg_contents .  | base64 | tr -d \"\\n\"")
+    let reg_contents = escape(reg_contents, '\')
+    let reg_contents = escape(reg_contents, '\\')
+    let reg_contents = escape(reg_contents, '"')
+    let reg_contents = escape(reg_contents, '$')
+    let base64_contents = system('echo -n "'. reg_contents .'" | base64 |' .  "tr -d '\\n'")
     let osc52 = "\<Esc>]52;c;" . base64_contents . "\<Esc>\\"
 "   $TTY env var is unset by vim, so _TTY should be set in your .bashrc/.zshrc
     let current_tty = $_TTY

--- a/zshenv
+++ b/zshenv
@@ -1,6 +1,7 @@
 # return eary for non-interactive mode (e.g scp/rsync)
 [[ "$-" =~ i ]] || return
 [ -n "${SHOW_SOURCE:-}" ] && echo "====start scriptting $0===="
+export _TTY=$TTY # for vim yank
 case ${OSTYPE} in
 darwin*)
     export SHELL=/usr/local/bin/zsh


### PR DESCRIPTION
This PR allows vim yank in remote env to local machine's clipboard where x11 forwarding is disabled.

This PR add logic to write OSC 52 command to tty slave when vim contents are yanked.
As It's passed to terminal emulator to set client machine's clipboard, your terminal emulator should be able to handle OSC 52 command. (See [here](https://jdhao.github.io/2021/01/05/nvim_copy_from_remote_via_osc52/#enable-osc-52-in-iterm2) for example).


